### PR TITLE
do not subscribe if field is empty

### DIFF
--- a/rqt_multiplot/src/rqt_multiplot/PlotCurve.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/PlotCurve.cpp
@@ -175,9 +175,14 @@ void PlotCurve::detach() {
 }
 
 void PlotCurve::run() {
-  if (paused_) {
+  CurveAxisConfig* xAxisConfig = config_->getAxisConfig(CurveConfig::X);
+  CurveAxisConfig* yAxisConfig = config_->getAxisConfig(CurveConfig::Y);
+
+  if (paused_ &&
+      !xAxisConfig->getField().isEmpty() &&
+      !yAxisConfig->getField().isEmpty()) {
     dataSequencer_->subscribe();
-    
+
     paused_ = false;
   }
 }
@@ -185,7 +190,7 @@ void PlotCurve::run() {
 void PlotCurve::pause() {
   if (!paused_) {
     dataSequencer_->unsubscribe();
-    
+
     paused_ = true;
   }
 }


### PR DESCRIPTION
Subscribing with an empty field throws a NoSuchMemberException
in the first processMessage call from CurveDataSequencer.
