### PR TITLE
Fix/axis jumping

### DIFF
--- a/rqt_multiplot/CMakeLists.txt
+++ b/rqt_multiplot/CMakeLists.txt
@@ -127,6 +127,7 @@ set(rqt_multiplot_SRCS
   src/rqt_multiplot/PlotZoomerMachine.cpp
   src/rqt_multiplot/ProgressChangeEvent.cpp
   src/rqt_multiplot/ProgressWidget.cpp
+  src/rqt_multiplot/QwtPlotCustom.cpp
   src/rqt_multiplot/StatusWidget.cpp
   src/rqt_multiplot/ThreadedTimer.cpp
   src/rqt_multiplot/UrlComboBox.cpp
@@ -135,7 +136,6 @@ set(rqt_multiplot_SRCS
   src/rqt_multiplot/UrlItemModel.cpp
   src/rqt_multiplot/UrlScheme.cpp
   src/rqt_multiplot/XmlSettings.cpp
-  src/rqt_multiplot/QwtPlotCustom.cpp
 )
 
 set(rqt_multiplot_HDRS
@@ -218,6 +218,7 @@ set(rqt_multiplot_HDRS
   include/rqt_multiplot/PlotZoomerMachine.h
   include/rqt_multiplot/ProgressChangeEvent.h
   include/rqt_multiplot/ProgressWidget.h
+  include/rqt_multiplot/QwtPlotCustom.h
   include/rqt_multiplot/StatusWidget.h
   include/rqt_multiplot/ThreadedTimer.h
   include/rqt_multiplot/UrlComboBox.h
@@ -226,7 +227,6 @@ set(rqt_multiplot_HDRS
   include/rqt_multiplot/UrlItemModel.h
   include/rqt_multiplot/UrlScheme.h
   include/rqt_multiplot/XmlSettings.h
-  include/rqt_multiplot/QwtPlotCustom.h
 )
 
 set(rqt_multiplot_UIS

--- a/rqt_multiplot/CMakeLists.txt
+++ b/rqt_multiplot/CMakeLists.txt
@@ -135,6 +135,7 @@ set(rqt_multiplot_SRCS
   src/rqt_multiplot/UrlItemModel.cpp
   src/rqt_multiplot/UrlScheme.cpp
   src/rqt_multiplot/XmlSettings.cpp
+  src/rqt_multiplot/QwtPlotCustom.cpp
 )
 
 set(rqt_multiplot_HDRS
@@ -225,6 +226,7 @@ set(rqt_multiplot_HDRS
   include/rqt_multiplot/UrlItemModel.h
   include/rqt_multiplot/UrlScheme.h
   include/rqt_multiplot/XmlSettings.h
+  include/rqt_multiplot/QwtPlotCustom.h
 )
 
 set(rqt_multiplot_UIS

--- a/rqt_multiplot/include/rqt_multiplot/QwtPlotCustom.h
+++ b/rqt_multiplot/include/rqt_multiplot/QwtPlotCustom.h
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * Copyright (C) 2015 by Ralf Kaestner, Samuel Bachmann                       *
+ * ralf.kaestner@gmail.com                                                    *
+ *                                                                            *
+ * This program is free software; you can redistribute it and/or modify       *
+ * it under the terms of the Lesser GNU General Public License as published by*
+ * the Free Software Foundation; either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * Lesser GNU General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the Lesser GNU General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ ******************************************************************************/
+
+#pragma once
+
+#include <qwt/qwt_plot.h>
+
+namespace rqt_multiplot {
+
+class QwtPlotCustom : public QwtPlot {
+Q_OBJECT
+public:
+  QwtPlotCustom(QWidget* = NULL );
+
+  QwtPlotCustom(const QwtText &title, QWidget *p = NULL );
+
+  virtual QSize sizeHint() const;
+
+  virtual QSize minimumSizeHint() const;
+};
+
+}

--- a/rqt_multiplot/src/rqt_multiplot/PlotWidget.ui
+++ b/rqt_multiplot/src/rqt_multiplot/PlotWidget.ui
@@ -214,7 +214,7 @@
     </spacer>
    </item>
    <item row="1" column="0" colspan="8">
-    <widget class="QwtPlot" name="plot">
+    <widget class="rqt_multiplot::QwtPlotCustom" name="plot">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
@@ -312,9 +312,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QwtPlot</class>
-   <extends>QFrame</extends>
-   <header>qwt_plot.h</header>
+   <class>rqt_multiplot::QwtPlotCustom</class>
+   <extends>QwtPlot</extends>
+   <header>rqt_multiplot/QwtPlotCustom.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/rqt_multiplot/src/rqt_multiplot/QwtPlotCustom.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/QwtPlotCustom.cpp
@@ -1,0 +1,23 @@
+#include "rqt_multiplot/QwtPlotCustom.h"
+
+namespace rqt_multiplot {
+
+QwtPlotCustom::QwtPlotCustom(QWidget *parent)
+    : QwtPlot(parent) {
+
+}
+
+QwtPlotCustom::QwtPlotCustom(const QwtText &title, QWidget *p)
+    : QwtPlot(title, p) {
+
+}
+
+QSize QwtPlotCustom::sizeHint() const {
+  return QSize(100, 100);
+}
+
+QSize QwtPlotCustom::minimumSizeHint() const {
+  return QSize(100, 100);
+}
+
+}

--- a/rqt_multiplot/src/rqt_multiplot/QwtPlotCustom.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/QwtPlotCustom.cpp
@@ -4,7 +4,8 @@ namespace rqt_multiplot {
 
 QwtPlotCustom::QwtPlotCustom(QWidget *parent)
     : QwtPlot(parent) {
-
+//  setAxisLabelRotation(QwtPlot::xBottom, -10.0);
+  setAxisLabelAlignment(QwtPlot::xBottom, Qt::AlignLeft | Qt::AlignBottom);
 }
 
 QwtPlotCustom::QwtPlotCustom(const QwtText &title, QWidget *p)


### PR DESCRIPTION
With long (time) labels on the x-axis, the plot jumps every time when a new label is added to the axis. Now the labels are aligned on the left side of the marker.