### PR TITLE
Arg parsing for the command line script

### DIFF
--- a/rqt_multiplot/.gitignore
+++ b/rqt_multiplot/.gitignore
@@ -1,0 +1,2 @@
+.project
+.pydevproject

--- a/rqt_multiplot/CMakeLists.txt
+++ b/rqt_multiplot/CMakeLists.txt
@@ -318,9 +318,6 @@ install(TARGETS rqt_multiplot
 )
 
 install(PROGRAMS scripts/rqt_multiplot
-  DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
-install(PROGRAMS scripts/rqt_multiplot
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/rqt_multiplot/scripts/rqt_multiplot
+++ b/rqt_multiplot/scripts/rqt_multiplot
@@ -8,13 +8,11 @@ from rqt_gui.main import Main
 def add_arguments(parser):
     group = parser.add_argument_group('Options for rqt_multiplot plugin')
     group.add_argument(
-        '-c',
         '--multiplot-config',
         default="",
         action='store',
         help='Load an xml plot configuration')
     group.add_argument(
-        '-b',
         '--multiplot-bag',
         default="",
         action='store',

--- a/rqt_multiplot/scripts/rqt_multiplot
+++ b/rqt_multiplot/scripts/rqt_multiplot
@@ -4,5 +4,21 @@ import sys
 
 from rqt_gui.main import Main
 
+
+def add_arguments(parser):
+    group = parser.add_argument_group('Options for rqt_multiplot plugin')
+    group.add_argument(
+        '-c',
+        '--multiplot-config',
+        default="",
+        action='store',
+        help='Load an xml plot configuration')
+    group.add_argument(
+        '-b',
+        '--multiplot-bag',
+        default="",
+        action='store',
+        help='Load a bag into multiplot')
+
 main = Main()
-sys.exit(main.main(sys.argv, standalone='MultiplotPlugin'))
+sys.exit(main.main(sys.argv, standalone='MultiplotPlugin', plugin_argument_provider=add_arguments))

--- a/rqt_multiplot/scripts/rqt_multiplot
+++ b/rqt_multiplot/scripts/rqt_multiplot
@@ -12,11 +12,12 @@ def add_arguments(parser):
         default="",
         action='store',
         help='Load an xml plot configuration')
-    group.add_argument(
-        '--multiplot-bag',
-        default="",
-        action='store',
-        help='Load a bag into multiplot')
+    # needs more tlc (i.e. doesn't actually work) - see https://github.com/ethz-asl/rqt_multiplot_plugin/pull/10
+    # group.add_argument(
+    #     '--multiplot-bag',
+    #     default="",
+    #     action='store',
+    #     help='Load a bag into multiplot')
 
 main = Main()
 sys.exit(main.main(sys.argv, standalone='MultiplotPlugin', plugin_argument_provider=add_arguments))

--- a/rqt_multiplot/setup.py
+++ b/rqt_multiplot/setup.py
@@ -3,6 +3,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
 packages=['rqt_multiplot'],
-package_dir={'': 'src'}
+package_dir={'': 'src'},
+scripts=['scripts/rqt_multiplot'],
 )
 setup(**d)

--- a/rqt_multiplot/src/rqt_multiplot/MultiplotPlugin.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/MultiplotPlugin.cpp
@@ -52,9 +52,9 @@ MultiplotPlugin::~MultiplotPlugin() {
 
 void MultiplotPlugin::initPlugin(qt_gui_cpp::PluginContext& context) {
   widget_ = new MultiplotWidget();
-  
+
   context.addWidget(widget_);
-  
+
   parseArguments(context.argv());
 }
 
@@ -65,12 +65,12 @@ void MultiplotPlugin::saveSettings(qt_gui_cpp::Settings& pluginSettings,
     qt_gui_cpp::Settings& instanceSettings) const {
   size_t maxConfigHistoryLength = widget_->getMaxConfigHistoryLength();
   QStringList configHistory = widget_->getConfigHistory();
-  
+
   instanceSettings.remove("history");
-  
+
   instanceSettings.setValue("history/max_length",
     (unsigned int)maxConfigHistoryLength);
-  
+
   for (size_t i = 0; i < configHistory.count(); ++i)
     instanceSettings.setValue("history/config_"+QString::number(i),
       configHistory[i]);
@@ -79,8 +79,12 @@ void MultiplotPlugin::saveSettings(qt_gui_cpp::Settings& pluginSettings,
 void MultiplotPlugin::restoreSettings(const qt_gui_cpp::Settings&
     pluginSettings, const qt_gui_cpp::Settings& instanceSettings) {
   size_t maxConfigHistoryLength = widget_->getMaxConfigHistoryLength();
-  QStringList configHistory;
-  
+
+  // the config history may already be populated with one element
+  // loaded from the command line, make sure that is kept before
+  // appending more.
+  QStringList configHistory = widget_->getConfigHistory();
+
   maxConfigHistoryLength = instanceSettings.value("history/max_length",
     (unsigned int)maxConfigHistoryLength).toUInt();
 
@@ -88,7 +92,7 @@ void MultiplotPlugin::restoreSettings(const qt_gui_cpp::Settings&
       number(configHistory.count())))
     configHistory.append(instanceSettings.value("history/config_"+
       QString::number(configHistory.count())).toString());
-    
+
   widget_->setMaxConfigHistoryLength(maxConfigHistoryLength);
   widget_->setConfigHistory(configHistory);
 }
@@ -96,7 +100,7 @@ void MultiplotPlugin::restoreSettings(const qt_gui_cpp::Settings&
 void MultiplotPlugin::parseArguments(const QStringList& arguments) {
   size_t argc = arguments.count();
   std::vector<QByteArray> args;
-  
+
   const char *argv[argc+1];
   argv[0] = "rqt_multiplot";
 
@@ -107,7 +111,7 @@ void MultiplotPlugin::parseArguments(const QStringList& arguments) {
 
   boost::program_options::variables_map variables;
   boost::program_options::options_description options;
-  
+
   options.add_options()
     ("multiplot-config,c", boost::program_options::value<std::string>(), "");
   options.add_options()

--- a/rqt_multiplot/src/rqt_multiplot/MultiplotPlugin.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/MultiplotPlugin.cpp
@@ -21,6 +21,7 @@
 
 #include <QByteArray>
 #include <QCloseEvent>
+#include <QUrl>
 
 #include <boost/program_options.hpp>
 
@@ -122,9 +123,10 @@ void MultiplotPlugin::parseArguments(const QStringList& arguments) {
       argc+1, argv, options), variables);
     boost::program_options::notify(variables);
 
-    if (variables.count("multiplot-config"))
-      widget_->loadConfig(QString::fromStdString(
-        variables["multiplot-config"].as<std::string>()));
+    if (variables.count("multiplot-config")) {
+      QUrl url = QUrl::fromUserInput(QString::fromStdString(variables["multiplot-config"].as<std::string>()));
+      widget_->loadConfig(url.toString());
+    }
     if (variables.count("multiplot-bag"))
       widget_->readBag(QString::fromStdString(
         variables["multiplot-bag"].as<std::string>()));


### PR DESCRIPTION
This reflects the arguments already available in the c++ plugin code and makes them available via the python script.

Question...how did you test/use the c++ plugin command line arguments previously?