### PR TITLE
Make your library usable

### DIFF
--- a/rqt_multiplot/CMakeLists.txt
+++ b/rqt_multiplot/CMakeLists.txt
@@ -301,8 +301,8 @@ else()
   target_link_libraries(${PROJECT_NAME} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY})
 endif()
 
-find_package(class_loader)
-class_loader_hide_library_symbols(rqt_multiplot)
+#find_package(class_loader)
+#class_loader_hide_library_symbols(rqt_multiplot)
 
 install(FILES plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
I cannot use this plugin library in my project because of the lines 304 and 305 in the CMakeLists.txt.

I am developing an ROS C++ Plugin, [rqt_alliance](https://github.com/adrianohrl/rqt_alliance), for monitoring the running, parameter-based, [ALLIANCE](https://github.com/adrianohrl/alliance) architecture for Multi-Robot Task Allocation problem solving.

By selecting a pair of robot and task (i.e. a behaviour set of a robot), it is desired to visualize multiple plots (via its respective topics) so that its motivation parametrization may be improved. Since the rqt_multiplot Plugin has the capability of doing that, my intention is to simplify it.